### PR TITLE
Fix: Copying doesn't work via CLI nor TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-cli"
-version = "0.1.57"
+version = "0.1.62"
 dependencies = [
  "anyhow",
  "atty",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can install [from the AUR](https://aur.archlinux.org/packages/thoth) using a
 ```bash
 paru -S thoth
 ```
+Or
+```bash
+yay -S thoth
+```
 
 ### Debian/Ubuntu
 You can install the `.deb` for your platform by doing the following (note: the URL is an example. To get the latest release please look at the [Releases](https://github.com/jooaf/thoth/releases) section)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,8 +145,9 @@ pub fn copy_block(name: &str) -> Result<()> {
             let mut ctx = result_ctx.unwrap();
 
             let is_success = ctx.set_contents(block_content.join("\n"));
+            let get_content_success = ctx.get_contents();
 
-            if is_success.is_err() {
+            if is_success.is_err() || get_content_success.is_err() {
                 bail!(format!(
                     "Failed to copy contents of block {} to system clipboard",
                     block_name

--- a/src/scrollable_textarea.rs
+++ b/src/scrollable_textarea.rs
@@ -148,6 +148,8 @@ impl ScrollableTextArea {
                 .map_err(|e| anyhow::anyhow!("Failed to create clipboard context: {}", e))?;
             ctx.set_contents(content)
                 .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
+            ctx.get_contents()
+                .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
         }
         Ok(())
     }
@@ -218,6 +220,8 @@ impl ScrollableTextArea {
             let content = textarea.lines().join("\n");
             let mut ctx = ClipboardContext::new().unwrap();
             ctx.set_contents(content).unwrap();
+            ctx.get_contents()
+                .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
         }
         Ok(())
     }
@@ -233,6 +237,8 @@ impl ScrollableTextArea {
                 let content = all_lines[min_row..max_row].join("\n");
                 let mut ctx = ClipboardContext::new().unwrap();
                 ctx.set_contents(content).unwrap();
+                ctx.get_contents()
+                    .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
             }
         }
         // reset selection


### PR DESCRIPTION
This PR provides a fix for this [issue](https://github.com/jooaf/thoth/issues/8). @alban-b mentioned that there were issues with copying from CLI using `thoth copy` and within the TUI. I added a fix based on this Stackoverflow page reference: https://stackoverflow.com/questions/73190617/weird-issue-with-copypasta-rust-crate-whilst-setting-clipboard-context-set-co 

## Testing 
I built and ran the code in this PR on my linux machine (Linux 23.1.4 Manjaro Linux) using Alacritty and Wezterm. I also verified that I am running X11 on my machine via running `ls /tmp/.X11-unix/`. It appears that everything is working on my machine but I will check to see if this works on Arch Linux.