### PR TITLE
Fix: clipboard on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,12 +91,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arboard"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
+dependencies = [
+ "clipboard-win",
+ "core-graphics",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "windows-sys 0.48.0",
+ "x11rb",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -135,36 +153,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block"
-version = "0.1.6"
+name = "block2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "calloop"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "bitflags 2.6.0",
- "log",
- "polling",
- "rustix",
- "slab",
- "thiserror",
+ "objc2",
 ]
 
 [[package]]
-name = "calloop-wayland-source"
-version = "0.3.0"
+name = "bytemuck"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
-dependencies = [
- "calloop",
- "rustix",
- "wayland-backend",
- "wayland-client",
-]
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cassowary"
@@ -235,12 +242,11 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clipboard-win"
-version = "3.1.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
- "lazy-bytes-cast",
- "winapi",
+ "error-code",
 ]
 
 [[package]]
@@ -263,26 +269,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "crossbeam-utils",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
-name = "copypasta"
-version = "0.10.1"
+name = "core-foundation-sys"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb85422867ca93da58b7f95fb5c0c10f6183ed6e1ef8841568968a896d3a858"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
- "clipboard-win",
- "objc",
- "objc-foundation",
- "objc_id",
- "smithay-clipboard",
- "x11-clipboard",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
 ]
 
 [[package]]
@@ -293,12 +316,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -324,12 +341,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "cursor-icon"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "custom_error"
@@ -374,25 +385,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -417,10 +413,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "flate2"
@@ -446,6 +457,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fragile"
@@ -509,10 +547,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
+name = "image"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+ "tiff",
+]
 
 [[package]]
 name = "indexmap"
@@ -564,10 +609,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "lazy-bytes-cast"
-version = "5.0.1"
+name = "jpeg-decoder"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "lazy_static"
@@ -580,16 +625,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "libredox"
@@ -639,28 +674,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -669,6 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -732,32 +750,102 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
+name = "objc-sys"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
- "malloc_buf",
+ "objc-sys",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
+name = "objc2-app-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "block",
- "objc",
- "objc_id",
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
+name = "objc2-core-data"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "objc",
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -824,12 +912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,24 +925,22 @@ checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.32.0",
+ "quick-xml",
  "serde",
  "time",
 ]
 
 [[package]]
-name = "polling"
-version = "3.7.2"
+name = "png"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.52.0",
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -947,15 +1027,6 @@ name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
 dependencies = [
  "memchr",
 ]
@@ -1124,12 +1195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,55 +1262,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.9"
+name = "simd-adler32"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "smithay-client-toolkit"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
-dependencies = [
- "bitflags 2.6.0",
- "calloop",
- "calloop-wayland-source",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix",
- "thiserror",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smithay-clipboard"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
-dependencies = [
- "libc",
- "smithay-client-toolkit",
- "wayland-backend",
-]
 
 [[package]]
 name = "stability"
@@ -1386,12 +1412,12 @@ dependencies = [
 
 [[package]]
 name = "thoth-cli"
-version = "0.1.57"
+version = "0.1.62"
 dependencies = [
  "anyhow",
+ "arboard",
  "atty",
  "clap",
- "copypasta",
  "crossterm",
  "dirs",
  "mockall",
@@ -1406,6 +1432,17 @@ dependencies = [
  "tempfile",
  "tui-textarea",
  "unicode-width",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -1438,22 +1475,6 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
-
-[[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "tui-textarea"
@@ -1533,100 +1554,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.6"
+name = "weezl"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90e11ce2ca99c97b940ee83edbae9da2d56a08f9ea8158550fd77fa31722993"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e321577a0a165911bdcfb39cf029302479d7527b517ee58ab0f6ad09edf0943"
-dependencies = [
- "bitflags 2.6.0",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-csd-frame"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
-dependencies = [
- "bitflags 2.6.0",
- "cursor-icon",
- "wayland-backend",
-]
-
-[[package]]
-name = "wayland-cursor"
-version = "0.31.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef9489a8df197ebf3a8ce8a7a7f0a2320035c3743f3c1bd0bdbccf07ce64f95"
-dependencies = [
- "rustix",
- "wayland-client",
- "xcursor",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62989625a776e827cc0f15d41444a3cea5205b963c3a25be48ae1b52d6b4daaa"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953"
-dependencies = [
- "bitflags 2.6.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b56f89937f1cf2ee1f1259cf2936a17a1f45d8f0aa1019fae6d470d304cfa6"
-dependencies = [
- "proc-macro2",
- "quick-xml 0.34.0",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43676fe2daf68754ecf1d72026e4e6c15483198b5d24e888b74d3f22f887a148"
-dependencies = [
- "dlib",
- "log",
- "once_cell",
- "pkg-config",
-]
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"
@@ -1799,16 +1730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "x11-clipboard"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98785a09322d7446e28a13203d2cae1059a0dd3dfb32cb06d0a225f023d8286"
-dependencies = [
- "libc",
- "x11rb",
-]
-
-[[package]]
 name = "x11rb"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,18 +1745,6 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
-
-[[package]]
-name = "xcursor"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491ee231a51ae64a5b762114c3ac2104b967aadba1de45c86ca42cf051513b7"
-
-[[package]]
-name = "xkeysym"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "thoth-cli"
 version = "0.1.62"
 edition = "2021"
-authors = ["Joel Afriyie <joel.o.afriyie@gmail.com>", "Joel Afriyie <oren.beani@gmail.com>"]
+authors = [
+  "Joel Afriyie <joel.o.afriyie@gmail.com>",
+  "Joel Afriyie <oren.beani@gmail.com>",
+]
 description = "A terminal scratchpad akin to Heynote"
 license = "MIT"
 repository = "https://github.com/jooaf/thoth"
@@ -18,7 +21,6 @@ pulldown-cmark-to-cmark = "15.0.1"
 ratatui = "0.27.0"
 crossterm = { version = "0.27.0", features = ["bracketed-paste"] }
 tui-textarea = "0.5.1"
-copypasta = "0.10.1"
 anyhow = "1.0.86"
 clap = { version = "4.3", features = ["derive"] }
 dirs = "5.0"
@@ -28,6 +30,7 @@ syntect-tui = "3.0.2"
 unicode-width = "0.1.10"
 rand = "0.8.5"
 once_cell = "1.19.0"
+arboard = "3.4.1"
 
 [[bin]]
 name = "thoth"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,5 @@
+use crate::EditorClipboard;
 use anyhow::{bail, Result};
-use copypasta::{ClipboardContext, ClipboardProvider};
-
 use std::{
     fs::File,
     io::{BufRead, BufReader, Write},
@@ -136,7 +135,7 @@ pub fn copy_block(name: &str) -> Result<()> {
 
     for (block_name, block_content) in blocks {
         if block_name == name {
-            let result_ctx = ClipboardContext::new();
+            let result_ctx = EditorClipboard::new();
 
             if result_ctx.is_err() {
                 bail!("Failed to create clipboard context for copy block");

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,31 +1,44 @@
+use std::sync::{Arc, Mutex};
 #[cfg(target_os = "linux")]
-use std::thread;
+use std::thread; // Import Arc and Mutex
 
 #[cfg(target_os = "linux")]
 use arboard::SetExtLinux;
 use arboard::{Clipboard, Error};
+
 pub struct EditorClipboard {
-    clipboard: Clipboard,
+    clipboard: Arc<Mutex<Clipboard>>, // Wrap Clipboard in Arc<Mutex>
 }
 
 impl EditorClipboard {
     pub fn new() -> Result<EditorClipboard, Error> {
-        Clipboard::new().map(|c| EditorClipboard { clipboard: c })
+        Clipboard::new().map(|c| EditorClipboard {
+            clipboard: Arc::new(Mutex::new(c)), // Initialize with Arc<Mutex>
+        })
     }
+
     pub fn try_new() -> Option<EditorClipboard> {
         Self::new().ok()
     }
+
     #[cfg(not(target_os = "linux"))]
-    pub fn set_contents(self: &mut Self, content: String) -> Result<(), Error> {
-        self.clipboard.set_text(content)
+    pub fn set_contents(&mut self, content: String) -> Result<(), Error> {
+        let mut clipboard = self.clipboard.lock().unwrap(); // Lock the clipboard
+        clipboard.set_text(content)
     }
+
     #[cfg(target_os = "linux")]
-    pub fn set_content(self: &mut Self, content: String) -> Result<(), Error> {
-        thread::spawn(|| self.clipboard.set().wait().text(content));
+    pub fn set_contents(&mut self, content: String) -> Result<(), Error> {
+        let clipboard = Arc::clone(&self.clipboard); // Clone the Arc
+        thread::spawn(move || {
+            let mut clipboard = clipboard.lock().unwrap(); // Lock the clipboard inside the thread
+            clipboard.set().wait().text(content).unwrap();
+        });
         Ok(())
     }
 
-    pub fn get_content(self: &mut Self) -> Result<String, Error> {
-        self.clipboard.get_text()
+    pub fn get_content(&mut self) -> Result<String, Error> {
+        let mut clipboard = self.clipboard.lock().unwrap(); // Lock the clipboard
+        clipboard.get_text()
     }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,31 @@
+#[cfg(target_os = "linux")]
+use std::thread;
+
+#[cfg(target_os = "linux")]
+use arboard::SetExtLinux;
+use arboard::{Clipboard, Error};
+pub struct EditorClipboard {
+    clipboard: Clipboard,
+}
+
+impl EditorClipboard {
+    pub fn new() -> Result<EditorClipboard, Error> {
+        Clipboard::new().map(|c| EditorClipboard { clipboard: c })
+    }
+    pub fn try_new() -> Option<EditorClipboard> {
+        Self::new().ok()
+    }
+    #[cfg(not(target_os = "linux"))]
+    pub fn set_contents(self: &mut Self, content: String) -> Result<(), Error> {
+        self.clipboard.set_text(content)
+    }
+    #[cfg(target_os = "linux")]
+    pub fn set_content(self: &mut Self, content: String) -> Result<(), Error> {
+        thread::spawn(|| self.clipboard.set().wait().text(content));
+        Ok(())
+    }
+
+    pub fn get_content(self: &mut Self) -> Result<String, Error> {
+        self.clipboard.get_text()
+    }
+}

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,19 +1,19 @@
 use std::sync::{Arc, Mutex};
 #[cfg(target_os = "linux")]
-use std::thread; // Import Arc and Mutex
+use std::thread;
 
 #[cfg(target_os = "linux")]
 use arboard::SetExtLinux;
 use arboard::{Clipboard, Error};
 
 pub struct EditorClipboard {
-    clipboard: Arc<Mutex<Clipboard>>, // Wrap Clipboard in Arc<Mutex>
+    clipboard: Arc<Mutex<Clipboard>>,
 }
 
 impl EditorClipboard {
     pub fn new() -> Result<EditorClipboard, Error> {
         Clipboard::new().map(|c| EditorClipboard {
-            clipboard: Arc::new(Mutex::new(c)), // Initialize with Arc<Mutex>
+            clipboard: Arc::new(Mutex::new(c)),
         })
     }
 
@@ -23,22 +23,22 @@ impl EditorClipboard {
 
     #[cfg(not(target_os = "linux"))]
     pub fn set_contents(&mut self, content: String) -> Result<(), Error> {
-        let mut clipboard = self.clipboard.lock().unwrap(); // Lock the clipboard
+        let mut clipboard = self.clipboard.lock().unwrap();
         clipboard.set_text(content)
     }
 
     #[cfg(target_os = "linux")]
     pub fn set_contents(&mut self, content: String) -> Result<(), Error> {
-        let clipboard = Arc::clone(&self.clipboard); // Clone the Arc
+        let clipboard = Arc::clone(&self.clipboard);
         thread::spawn(move || {
-            let mut clipboard = clipboard.lock().unwrap(); // Lock the clipboard inside the thread
+            let mut clipboard = clipboard.lock().unwrap();
             clipboard.set().wait().text(content).unwrap();
         });
         Ok(())
     }
 
     pub fn get_content(&mut self) -> Result<String, Error> {
-        let mut clipboard = self.clipboard.lock().unwrap(); // Lock the clipboard
+        let mut clipboard = self.clipboard.lock().unwrap();
         clipboard.get_text()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod clipboard;
 pub mod formatter;
 pub mod markdown_renderer;
 pub mod scrollable_textarea;
@@ -8,15 +9,15 @@ pub mod ui;
 pub mod ui_handler;
 pub mod utils;
 
+pub use clipboard::EditorClipboard;
+use dirs::home_dir;
 pub use formatter::{format_json, format_markdown};
 pub use markdown_renderer::MarkdownRenderer;
 pub use scrollable_textarea::ScrollableTextArea;
+use std::path::PathBuf;
 pub use title_popup::TitlePopup;
 pub use title_select_popup::TitleSelectPopup;
 pub use utils::{load_textareas, save_textareas};
-
-use dirs::home_dir;
-use std::path::PathBuf;
 
 pub fn get_save_file_path() -> PathBuf {
     home_dir().unwrap_or_default().join("thoth_notes.md")

--- a/src/scrollable_textarea.rs
+++ b/src/scrollable_textarea.rs
@@ -5,10 +5,10 @@ use std::{
     rc::Rc,
 };
 
+use crate::EditorClipboard;
 use crate::{MarkdownRenderer, ORANGE};
 use anyhow;
 use anyhow::Result;
-use copypasta::{ClipboardContext, ClipboardProvider};
 use rand::Rng;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -144,7 +144,7 @@ impl ScrollableTextArea {
     pub fn copy_textarea_contents(&self) -> Result<()> {
         if let Some(textarea) = self.textareas.get(self.focused_index) {
             let content = textarea.lines().join("\n");
-            let mut ctx = ClipboardContext::new()
+            let mut ctx = EditorClipboard::new()
                 .map_err(|e| anyhow::anyhow!("Failed to create clipboard context: {}", e))?;
             ctx.set_contents(content)
                 .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
@@ -216,7 +216,7 @@ impl ScrollableTextArea {
     pub fn copy_focused_textarea_contents(&self) -> anyhow::Result<()> {
         if let Some(textarea) = self.textareas.get(self.focused_index) {
             let content = textarea.lines().join("\n");
-            let mut ctx = ClipboardContext::new().unwrap();
+            let mut ctx = EditorClipboard::new().unwrap();
             ctx.set_contents(content).unwrap();
         }
         Ok(())
@@ -231,7 +231,7 @@ impl ScrollableTextArea {
 
             if max_row <= all_lines.len() {
                 let content = all_lines[min_row..max_row].join("\n");
-                let mut ctx = ClipboardContext::new().unwrap();
+                let mut ctx = EditorClipboard::new().unwrap();
                 ctx.set_contents(content).unwrap();
             }
         }

--- a/src/ui_handler.rs
+++ b/src/ui_handler.rs
@@ -1,5 +1,5 @@
+use crate::EditorClipboard;
 use anyhow::{bail, Result};
-use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, KeyModifiers},
     execute,
@@ -32,7 +32,7 @@ pub struct UIState {
     pub title_select_popup: TitleSelectPopup,
     pub error_popup: ErrorPopup,
     pub edit_commands_popup: EditCommandsPopup,
-    pub clipboard: Option<ClipboardContext>,
+    pub clipboard: Option<EditorClipboard>,
     pub last_draw: Instant,
 }
 
@@ -55,7 +55,7 @@ impl UIState {
             title_select_popup: TitleSelectPopup::new(),
             error_popup: ErrorPopup::new(),
             edit_commands_popup: EditCommandsPopup::new(),
-            clipboard: ClipboardContext::new().ok(),
+            clipboard: EditorClipboard::try_new(),
             last_draw: Instant::now(),
         })
     }
@@ -476,7 +476,7 @@ fn handle_paste(state: &mut UIState) -> Result<()> {
     if state.scrollable_textarea.edit_mode {
         match &mut state.clipboard {
             Some(clip) => {
-                if let Ok(content) = clip.get_contents() {
+                if let Ok(content) = clip.get_content() {
                     let textarea = &mut state.scrollable_textarea.textareas
                         [state.scrollable_textarea.focused_index];
                     for line in content.lines() {


### PR DESCRIPTION
This PR introduces a possible fix for clipboard handling on simpler desktop environments. The implementation leverages multithreading to avoid blocking the main thread when interacting with the clipboard, improving responsiveness and compatibility with certain desktop environments.

- The `EditorClipboard` struct wraps the `arboard::Clipboard` functionality in a thread-safe `Arc<Mutex<Clipboard>>` to ensure safe concurrent access.
- Clipboard contents are set directly within the current thread for non-Linux platforms.
- For Linux platforms, clipboard contents are set asynchronously using a new thread to prevent blocking.

### Known Limitation

While this solution handles clipboard interaction in simpler DEs, there is a limitation. If the main program exits, the clipboard thread will also terminate (have not tested this but it is expected), meaning the clipboard contents may be lost. To allow clipboard contents to persist beyond the life of the program, a longer-lasting solution would be to spawn a daemon process. An example of how to implement this can be found in the [arboard daemonize example](https://github.com/1Password/arboard/blob/master/examples/daemonize.rs).
